### PR TITLE
Add GitSigns Highlight Group

### DIFF
--- a/lua/gruvbox-minimal/groups.lua
+++ b/lua/gruvbox-minimal/groups.lua
@@ -200,6 +200,13 @@ function M.setup(c, config)
 		RenderMarkdownUnchecked = { fg = c.red, bold = true },
 		RenderMarkdownChecked = { fg = c.green, bold = true },
 		RenderMarkdownBullet = { fg = c.yellow, bold = true },
+		--- lewis6991/gitsigns.nvim
+		GitSignsAdd = { fg = c.green },
+		GitSignsChange = { fg = c.blue },
+		GitSignsDelete = { fg = c.red },
+		GitSignsAddLn = { bg = c.bg_green },
+		GitSignsChangeLn = { bg = c.bg_blue },
+		GitSignsDeleteLn = { bg = c.bg_red },
 	}
 
 	groups = essential_groups


### PR DESCRIPTION
This PR adds the [GitSigns](https://github.com/lewis6991/gitsigns.nvim) plugin highlights. Below is a preview:

<img width="981" height="277" alt="Screenshot 2026-01-17 at 14 18 29" src="https://github.com/user-attachments/assets/e111ef1b-6fdf-4ff8-95c9-55b745b84e47" />


The `linehl` is enabled/disabled in the plugin itself (I have it on). By default it only highlights the `signcolumn`.