### PR TITLE
Make `FlashLabel` more noticable

### DIFF
--- a/lua/gruvbox-minimal/groups.lua
+++ b/lua/gruvbox-minimal/groups.lua
@@ -207,6 +207,8 @@ function M.setup(c, config)
 		GitSignsAddLn = { bg = c.bg_green },
 		GitSignsChangeLn = { bg = c.bg_blue },
 		GitSignsDeleteLn = { bg = c.bg_red },
+		-- folke/flash.nvim
+		FlashLabel = { fg = c.base_00, bg = c[config.accent] },
 	}
 
 	groups = essential_groups


### PR DESCRIPTION
This brings more contrast to the [Flash](https://github.com/folke/flash.nvim) plugin label. The other defaults were good as they were, but the label was not "contrast-y" enough so as to make the jump letter more clearer.
I thought a good default was to have this label follow the `accent` color the user chooses, but let me know if you think otherwise.

Before:
<img width="845" height="739" alt="before" src="https://github.com/user-attachments/assets/b5e988ba-967e-4d30-9df9-dd04be9ae850" />

After:
<img width="846" height="736" alt="after" src="https://github.com/user-attachments/assets/07608135-1d2e-4a20-939a-c999fa87b1d7" />
