### PR TITLE
Add Italic function option and ability to create overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,15 @@ The default configuration settings are as follows:
 require("gruvbox-minimal").setup({
 	transparent = false, -- Sets all the major background values to 'none'
 	italic_comments = false, -- Italic comments
+	italic_functions = true, -- Italic functions and methods
 	contrast = "low", -- Available values: "high", "low"
 	theme = "dark", -- Available values: "dark", "light"
 	accent = "red", -- Changes the definition (functions, structs etc.) colors. Available values: "red", "orange", "yellow", "green", "cyan", "blue", "magenta"
     semantic_highlights = true, -- Uses LSP semantic highlighting, disable this if you want the highlights of =< 0.3.1
+	overrides = {
+      -- Type = { fg = '#83a598' }, -- Hex override
+      -- ['Type'] = { link = '@function.method.call' }, -- Link to another group
+	},
 })
 
 -- Activates the colorscheme

--- a/lua/gruvbox-minimal/groups.lua
+++ b/lua/gruvbox-minimal/groups.lua
@@ -101,7 +101,7 @@ function M.setup(c, config)
 		Float = { fg = c.base_15 },
 		Operator = { fg = c.base_10 },
 		Identifier = { fg = c.base_15 },
-		Function = { fg = c[config.accent], italic = true },
+		Function = { fg = c[config.accent], italic = config.italic_functions },
 		Statement = { fg = c.base_15 },
 		Conditional = { fg = c.base_15 },
 		Repeat = { fg = c.base_15 },
@@ -133,8 +133,8 @@ function M.setup(c, config)
 		["@variable"] = { link = "Identifier" },
 		["@constant.builtin"] = { link = "Constant" },
 		["@function.builtin"] = { link = "Function" },
-		["@function.call"] = { fg = c.base_12, italic = true },
-		["@function.method.call"] = { fg = c.base_12, italic = true },
+		["@function.call"] = { fg = c.base_12, italic = config.italic_functions },
+		["@function.method.call"] = { fg = c.base_12, italic = config.italic_functions },
 		["@comment.error"] = { bg = c.red, fg = c.bg_red },
 		["@comment.warning"] = { bg = c.orange, fg = c.bg_orange },
 		["@comment.todo"] = { bg = c.green, fg = c.bg_green },
@@ -252,6 +252,10 @@ function M.setup(c, config)
 			["@lsp.mod.readonly.typescript"] = {},
 			["@lsp.mod.readonly.javascript"] = {},
 		})
+	end
+
+	if config.overrides and next(config.overrides) ~= nil then
+		groups = vim.tbl_deep_extend("force", groups, config.overrides)
 	end
 
 	return groups

--- a/lua/gruvbox-minimal/groups.lua
+++ b/lua/gruvbox-minimal/groups.lua
@@ -207,6 +207,8 @@ function M.setup(c, config)
 		GitSignsAddLn = { bg = c.bg_green },
 		GitSignsChangeLn = { bg = c.bg_blue },
 		GitSignsDeleteLn = { bg = c.bg_red },
+		-- folke/flash.nvim
+		FlashLabel = { fg = c.base_00, bg = c[config.accent] },
 	}
 
 	groups = essential_groups

--- a/lua/gruvbox-minimal/init.lua
+++ b/lua/gruvbox-minimal/init.lua
@@ -5,10 +5,12 @@
 --- @class GruvboxConfig
 --- @field transparent? boolean
 --- @field italic_comments? boolean
+--- @field italic_functions? boolean
 --- @field contrast? GruvboxContrast
 --- @field theme? GruvboxTheme
 --- @field accent? GruvboxAccent
 --- @field semantic_highlights? boolean
+--- @field overrides? table<string, table> -- accepts hex colors or links
 
 local M = {}
 
@@ -16,10 +18,12 @@ local M = {}
 M.config = {
 	transparent = false,
 	italic_comments = false,
+	italic_functions = true,
 	contrast = "low",
 	theme = "dark",
 	accent = "red",
 	semantic_highlights = true,
+	overrides = {},
 }
 
 --- @param opts? GruvboxConfig


### PR DESCRIPTION
This PR allows the user to configure whether or not he wants to have method and function names italicized or not (defaults to `true` as per the original behavior).

Also adds the option for the user to specify overrides to an Highlight group via explicit hex color assignment or by linking to another defined Highlight group. Example given in README.

Closes #4 