### PR TITLE
Add new Neovim 0.12 highlight for difftext

### DIFF
--- a/lua/gruvbox-minimal/groups.lua
+++ b/lua/gruvbox-minimal/groups.lua
@@ -70,6 +70,7 @@ function M.setup(c, config)
 		DiffChange = { fg = c.yellow },
 		DiffDelete = { fg = c.red },
 		DiffText = { fg = c.yellow, bg = c.bg_yellow },
+		DiffTextAdd = { fg = c.green, bg = c.bg_green },
 
 		-- Others
 		ColorColumn = { bg = c.base_03 },


### PR DESCRIPTION
Adds the new highlight that came with [version 0.12](https://neovim.io/doc/user/news-0.12/#_highlights) - `hl-DiffTextAdd`.
It essentially only changes the newly added text in `vimdiff` mode, which was previously considered just a change.
Preview:
<img width="1618" height="906" alt="dark" src="https://github.com/user-attachments/assets/5b1dd013-5faf-42bd-a73c-33ebe1a25127" />
<img width="1619" height="905" alt="light" src="https://github.com/user-attachments/assets/562460fe-4637-4c0f-8cc8-35e688fc8bed" />
